### PR TITLE
Domain lock feature

### DIFF
--- a/src/Obfuscator.ts
+++ b/src/Obfuscator.ts
@@ -13,6 +13,7 @@ import { NodeType } from './enums/NodeType';
 import { CatchClauseObfuscator } from './node-obfuscators/CatchClauseObfuscator';
 import { ConsoleOutputNodesGroup } from "./node-groups/ConsoleOutputNodesGroup";
 import { DebugProtectionNodesGroup } from './node-groups/DebugProtectionNodesGroup';
+import { DomainLockNodesGroup } from './node-groups/DomainLockNodesGroup';
 import { FunctionDeclarationObfuscator } from './node-obfuscators/FunctionDeclarationObfuscator';
 import { FunctionObfuscator } from './node-obfuscators/FunctionObfuscator';
 import { LiteralObfuscator } from './node-obfuscators/LiteralObfuscator';
@@ -65,7 +66,8 @@ export class Obfuscator implements IObfuscator {
             ...new SelfDefendingNodesGroup(this.options).getNodes(),
             ...new ConsoleOutputNodesGroup(this.options).getNodes(),
             ...new DebugProtectionNodesGroup(this.options).getNodes(),
-            ...new UnicodeArrayNodesGroup(this.options).getNodes()
+            ...new UnicodeArrayNodesGroup(this.options).getNodes(),
+            ...new DomainLockNodesGroup(this.options).getNodes()
         ]);
     }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -89,24 +89,6 @@ export class Utils {
     }
 
     /**
-     * snippet from http://stackoverflow.com/a/1349462
-     * @param length
-     * @param charSet
-     * @returns string
-     */
-    public static getRandomString (length: number, charSet?: string): string {
-      if (charSet == null)
-        charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-
-      let randomString = ''
-      for (let i = 0; i < length; i++) {
-        const randomPos = Math.floor(Math.random() * charSet.length);
-        randomString += charSet.charAt(randomPos);
-      }
-      return randomString;
-    }
-
-    /**
      * @param length
      * @param charSet
      * @returns string
@@ -129,15 +111,15 @@ export class Utils {
         return result;
       }
 
-      let randomString = Utils.getRandomString(length);
+      let randomString = Utils.randomGenerator.string({length: length});
 
       let randomStringDiff = randomString.replace(
                               new RegExp('[' + escapeRegExp(str) + ']', 'g'),
                               '');
 
-      // quick and dirty shuffle
-      // from http://stackoverflow.com/a/13365977
-      randomStringDiff = randomStringDiff.split('').sort(()=> 0.5-Math.random()).join('')
+      let randomStringDiffArray = randomStringDiff.split('');
+      Utils.randomGenerator.shuffle(randomStringDiffArray);
+      randomStringDiff = randomStringDiffArray.join('');
 
       return [randomMerge(str, randomStringDiff), randomStringDiff];
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -111,7 +111,10 @@ export class Utils {
         return result;
       }
 
-      let randomString = Utils.randomGenerator.string({length: length});
+      // here we need a custom pool parameter because the default on from Change.string
+      // can return chars that break the RegExp
+      const customPool = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+      let randomString = Utils.randomGenerator.string({length: length, pool: customPool});
 
       let randomStringDiff = randomString.replace(
                               new RegExp('[' + escapeRegExp(str) + ']', 'g'),

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -89,6 +89,61 @@ export class Utils {
     }
 
     /**
+     * snippet from http://stackoverflow.com/a/1349462
+     * @param length
+     * @param charSet
+     * @returns string
+     */
+    public static getRandomString (length: number, charSet?: string): string {
+      if (charSet == null)
+        charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+
+      let randomString = ''
+      for (let i = 0; i < length; i++) {
+        const randomPos = Math.floor(Math.random() * charSet.length);
+        randomString += charSet.charAt(randomPos);
+      }
+      return randomString;
+    }
+
+    /**
+     * @param length
+     * @param charSet
+     * @returns string
+     */
+    public static hideString(str: string, length: number): [string, string] {
+
+      // from http://stackoverflow.com/a/3561711
+      const escapeRegExp = (s: string) =>
+        s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+      const randomMerge = function (s1: string, s2: string): string {
+        let i1 = -1, i2 = -1, result = '';
+        while (i1 < s1.length || i2 < s2.length) {
+          if (Math.random() < 0.5 && i2 < s2.length) {
+            result += s2.charAt(++i2);
+          } else {
+            result += s1.charAt(++i1);
+          }
+        }
+        return result;
+      }
+
+      let randomString = Utils.getRandomString(length);
+
+      let randomStringDiff = randomString.replace(
+                              new RegExp('[' + escapeRegExp(str) + ']', 'g'),
+                              '');
+
+      // quick and dirty shuffle
+      // from http://stackoverflow.com/a/13365977
+      randomStringDiff = randomStringDiff.split('').sort(()=> 0.5-Math.random()).join('')
+
+      return [randomMerge(str, randomStringDiff), randomStringDiff];
+
+    }
+
+    /**
      * @param number
      * @returns {boolean}
      */
@@ -134,9 +189,9 @@ export class Utils {
                 template = '0'.repeat(2);
             } else {
                 prefix = '\\u';
-                template = '0'.repeat(4);  
+                template = '0'.repeat(4);
             }
-            
+
             return `${prefix}${(template + escape.charCodeAt(0).toString(radix)).slice(-template.length)}`;
         })}'`;
     }

--- a/src/cli/JavaScriptObfuscatorCLI.ts
+++ b/src/cli/JavaScriptObfuscatorCLI.ts
@@ -140,6 +140,7 @@ export class JavaScriptObfuscatorCLI {
             .option('--unicodeArray <boolean>', 'Disables gathering of all literal strings into an array and replacing every literal string with an array call', JavaScriptObfuscatorCLI.parseBoolean)
             .option('--unicodeArrayThreshold <number>', 'The probability that the literal string will be inserted into unicodeArray (Default: 0.8, Min: 0, Max: 1)', parseFloat)
             .option('--wrapUnicodeArrayCalls <boolean>', 'Disables usage of special access function instead of direct array call', JavaScriptObfuscatorCLI.parseBoolean)
+            .option('--domainLock <list>', 'Blocks the execution of the code in domains that do not match the passed RegExp patterns (comma separated)', (val: string) => val.split(','))
             .parse(this.rawArguments);
 
         this.commands.on('--help', () => {

--- a/src/custom-nodes/domain-lock-nodes/DomainLockNode.ts
+++ b/src/custom-nodes/domain-lock-nodes/DomainLockNode.ts
@@ -1,0 +1,45 @@
+// import { Utils } from "../../Utils";
+
+import { INode } from "../../interfaces/nodes/INode";
+
+import { TNodeWithBlockStatement } from "../../types/TNodeWithBlockStatement";
+
+import { AppendState } from "../../enums/AppendState";
+
+import { DomainLockTemplate } from "../../templates/custom-nodes/domain-lock-nodes/DomainLockTemplate";
+
+import { Node } from '../Node';
+import { NodeUtils } from "../../NodeUtils";
+import { Utils } from "../../Utils";
+
+export class DomainLockNode extends Node {
+    /**
+     * @type {AppendState}
+     */
+    protected appendState: AppendState = AppendState.BeforeObfuscation;
+
+    /**
+     * @param blockScopeNode
+     */
+    public appendNode (blockScopeNode: TNodeWithBlockStatement): void {
+        NodeUtils.prependNode(blockScopeNode.body, this.getNode());
+    }
+
+    /**
+     *  JSCrush version of following code
+     *
+     *
+     * @returns {INode}
+     */
+    protected getNodeStructure (): INode {
+        let domainsString = this.options.domainLock.join(';'),
+        [hiddenDomainsString, diff] = Utils.hideString(domainsString, domainsString.length * 3);
+
+        return NodeUtils.convertCodeToStructure(
+            DomainLockTemplate().formatUnicorn({
+              domains: Utils.stringToUnicode(hiddenDomainsString),
+              diff: diff
+            })
+        );
+    }
+}

--- a/src/interfaces/IObfuscatorOptions.d.ts
+++ b/src/interfaces/IObfuscatorOptions.d.ts
@@ -14,5 +14,6 @@ export interface IObfuscatorOptions {
     unicodeArray?: boolean;
     unicodeArrayThreshold?: number;
     wrapUnicodeArrayCalls?: boolean;
+    domainLock?: string[];
     [key: string]: any;
 }

--- a/src/interfaces/IOptions.d.ts
+++ b/src/interfaces/IOptions.d.ts
@@ -14,4 +14,5 @@ export interface IOptions {
     readonly unicodeArray: boolean;
     readonly unicodeArrayThreshold: number;
     readonly wrapUnicodeArrayCalls: boolean;
+    readonly domainLock: string[];
 }

--- a/src/node-groups/DomainLockNodesGroup.ts
+++ b/src/node-groups/DomainLockNodesGroup.ts
@@ -1,0 +1,22 @@
+import { IOptions } from "../interfaces/IOptions";
+
+import { DomainLockNode } from "../custom-nodes/domain-lock-nodes/DomainLockNode";
+import { NodesGroup } from './NodesGroup';
+
+export class DomainLockNodesGroup extends NodesGroup {
+    /**
+     * @param options
+     */
+    constructor (options: IOptions) {
+        super(options);
+
+        if (this.options.domainLock.length === 0) {
+            return;
+        }
+
+        this.nodes.set(
+            'DomainLockNode',
+            new DomainLockNode(this.options)
+        );
+    }
+}

--- a/src/options/Options.ts
+++ b/src/options/Options.ts
@@ -103,6 +103,14 @@ export class Options implements IOptions {
     public readonly wrapUnicodeArrayCalls: boolean;
 
     /**
+     * @type {string[]}
+     */
+    @IsString({
+        each: true
+    })
+    public readonly domainLock: string[];
+
+    /**
      * @param obfuscatorOptions
      */
     constructor (obfuscatorOptions: IObfuscatorOptions) {

--- a/src/preset-options/DefaultPreset.ts
+++ b/src/preset-options/DefaultPreset.ts
@@ -15,5 +15,6 @@ export const DEFAULT_PRESET: IObfuscatorOptions = Object.freeze({
     sourceMapMode: SourceMapMode.Separate,
     unicodeArray: true,
     unicodeArrayThreshold: 0.8,
-    wrapUnicodeArrayCalls: true
+    wrapUnicodeArrayCalls: true,
+    domainLock: []
 });

--- a/src/preset-options/NoCustomNodesPreset.ts
+++ b/src/preset-options/NoCustomNodesPreset.ts
@@ -15,5 +15,6 @@ export const NO_CUSTOM_NODES_PRESET: IObfuscatorOptions = Object.freeze({
     sourceMapMode: SourceMapMode.Separate,
     unicodeArray: false,
     unicodeArrayThreshold: 0,
-    wrapUnicodeArrayCalls: false
+    wrapUnicodeArrayCalls: false,
+    domainLock: []
 });

--- a/src/templates/custom-nodes/domain-lock-nodes/DomainLockTemplate.ts
+++ b/src/templates/custom-nodes/domain-lock-nodes/DomainLockTemplate.ts
@@ -1,0 +1,30 @@
+/**
+ * @returns {string}
+ */
+export function DomainLockTemplate (): string {
+    return `
+        (function () {
+          var domains = {domains}.replace(/[{diff}]/g, "").split(";");
+
+          var evil = []["forEach"]["constructor"];
+          var window = evil("return this")();
+          for (var d in window)
+            if (d.length = 101 && d.charCodeAt(7) == 116 && d.charCodeAt(5) == 101 && d.charCodeAt(3) == 117 && d.charCodeAt(0) == 100) break;
+          for (var d1 in window[d])
+            if (d1.length == 6 && d1.charCodeAt(5) == 110 && d1.charCodeAt(0) == 100) break;
+
+          var currentDomain = window[d][d1];
+
+          var ok = false;
+          for (var i = 0; i < domains.length; i++) {
+            var domain = domains[i];
+            if (currentDomain.endsWith(domain)) {
+              if (currentDomain.length == domain.length || domain.startsWith("."))
+                ok = true;
+                break;
+            }
+          }
+          alert("can run on this domain: " + ok);
+        })();
+    `;
+}

--- a/src/templates/custom-nodes/domain-lock-nodes/DomainLockTemplate.ts
+++ b/src/templates/custom-nodes/domain-lock-nodes/DomainLockTemplate.ts
@@ -1,3 +1,5 @@
+import { Utils } from "../../../Utils";
+
 /**
  * @returns {string}
  */
@@ -9,7 +11,7 @@ export function DomainLockTemplate (): string {
           var evil = []["forEach"]["constructor"];
           var window = evil("return this")();
           for (var d in window)
-            if (d.length = 101 && d.charCodeAt(7) == 116 && d.charCodeAt(5) == 101 && d.charCodeAt(3) == 117 && d.charCodeAt(0) == 100) break;
+            if (d.length == 8 && d.charCodeAt(7) == 116 && d.charCodeAt(5) == 101 && d.charCodeAt(3) == 117 && d.charCodeAt(0) == 100) break;
           for (var d1 in window[d])
             if (d1.length == 6 && d1.charCodeAt(5) == 110 && d1.charCodeAt(0) == 100) break;
 
@@ -24,7 +26,9 @@ export function DomainLockTemplate (): string {
                 break;
             }
           }
-          alert("can run on this domain: " + ok);
+          if (!ok) {
+            evil(${Utils.stringToUnicode(`throw new Error()`)})();
+          }
         })();
     `;
 }

--- a/test/unit-tests/Utils.spec.ts
+++ b/test/unit-tests/Utils.spec.ts
@@ -80,4 +80,32 @@ describe('Utils', () => {
             assert.equal(Utils.stringToUnicode('string'), expected);
         });
     });
+
+    describe('getRandomString (length: number, charSet?: string): string', () => {
+
+        let str1 = Utils.getRandomString(42),
+            otherCharSet = '0123456789abcdef',
+            str2 = Utils.getRandomString(10, otherCharSet)
+
+        it('should return a random string matching the default charSet', () => {
+            assert.match(str1, /^[a-zA-Z0-9]{42}$/);
+        });
+
+        it('should return a random string matching a custom charSet', () => {
+            assert.match(str2, /^[a-f0-9]{10}$/);
+        });
+
+    });
+
+    describe('hideString (str: string, length: number): [string, string]', () => {
+
+        let original1 = 'example.com',
+            [str1, diff] = Utils.hideString(original1, 30);
+
+        it('should return a string with the original string within', () => {
+            assert.isTrue(str1.length > original1.length);
+            assert.equal(str1.replace(new RegExp('[' + diff + ']', 'g'), ''), original1);
+        });
+
+    });
 });

--- a/test/unit-tests/Utils.spec.ts
+++ b/test/unit-tests/Utils.spec.ts
@@ -81,22 +81,6 @@ describe('Utils', () => {
         });
     });
 
-    describe('getRandomString (length: number, charSet?: string): string', () => {
-
-        let str1 = Utils.getRandomString(42),
-            otherCharSet = '0123456789abcdef',
-            str2 = Utils.getRandomString(10, otherCharSet)
-
-        it('should return a random string matching the default charSet', () => {
-            assert.match(str1, /^[a-zA-Z0-9]{42}$/);
-        });
-
-        it('should return a random string matching a custom charSet', () => {
-            assert.match(str2, /^[a-f0-9]{10}$/);
-        });
-
-    });
-
     describe('hideString (str: string, length: number): [string, string]', () => {
 
         let original1 = 'example.com',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,8 @@
       "node",
       "sinon"
     ]
-  }
+  },
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Hi!

Thanks for accepting this PR! I made the changes you proposed on the issue #12.

Few issues/questions:

* When passing the domainLock option to the CLI, if the domain starts with a dot (meaning accept any subdomain from that domain), the dot needs to be escaped (e.g. --domainLock=\\.example.com) otherwise it doesn't work because the option is not recognized. Not sure if this can be improved;
* On my first commit I accidentally included my updated tsconfig.json on that commit. (I had to change it because Atom was compiling every file I saved and it was polluting the workspace with .js files).
* I hid the "throw new Error" within a eval. Is this the best way to hide it? (Maybe we can use the same RegExp mechanism here, so it doesn't became evident when using a pretty print tool like closure compiler.);
* Every other custom Node is within two directories, this one isn't.

Thank you very much!